### PR TITLE
Update React to v19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
         "react-medium-image-zoom": "^4.3.1",
         "react-router-dom": "^6.22.3",
         "react-scripts": "^5.0.1",
@@ -15324,8 +15324,8 @@
       "integrity": "sha512-Ix7ALha91aOEwiHuxumCeYbARS5XNpc/w0v145oGkM6poF/CvhKJwzLhM5sEZbtrghMA+psAhOJkCTzJoseicA==",
       "peer": true,
       "dependencies": {
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
         "resize-observer-polyfill": "^1.5.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "server/server.js",
   "proxy": "http://localhost:4000",
   "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "react-medium-image-zoom": "^4.3.1",
     "react-router-dom": "^6.22.3",
     "react-scripts": "^5.0.1",


### PR DESCRIPTION
## Summary
- bump react and react-dom dependencies to v19 in package.json
- update lock file references

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68436a927ddc832d87ad0b13a79e7333